### PR TITLE
Use idempotent ATA creation to avoid tx race conditions

### DIFF
--- a/src/spl/spl.ts
+++ b/src/spl/spl.ts
@@ -1,5 +1,5 @@
 import {
-  createAssociatedTokenAccountInstruction,
+  createAssociatedTokenAccountIdempotentInstruction,
   createCloseAccountInstruction,
   createInitializeAccountInstruction,
   createInitializeMintInstruction,
@@ -49,7 +49,7 @@ export class Spl {
     instructionsType: InstructionType[]
   }) {
     instructionsType.push(InstructionType.createATA)
-    return createAssociatedTokenAccountInstruction(payer, associatedAccount, owner, mint, programId)
+    return createAssociatedTokenAccountIdempotentInstruction(payer, associatedAccount, owner, mint, programId)
   }
 
   // https://github.com/solana-labs/solana-program-library/blob/master/token/js/client/token.js


### PR DESCRIPTION
Raydium-sdk code is prone to race conditions for cases when an ATA is checked for existence, then a `createAssociatedTokenAccountInstruction` is added to the tx.

If two swaps detect the ATA missing and add the ATA creation instruction, only the first will succeed, while the second will fail with `InvalidOwner`.

Example:
- https://solscan.io/tx/6UdPne1GQXKNWSyFGQmVg6RrNvAQH1aabYMfX5WWkXDMsFR5HeKPpiKkQ1Nhk1VFAahWjiZRD6WX3yd4V3HFtqL - successful
- https://solscan.io/tx/47jDCHj3wszKMr6pPZ5PGaGXAkp23ZuT5Gm61LKrocGumWsyNp4Pv5EMTrqqSJjJLUCnrM1Jokr78x3VfipyJ5jk - failed

This PR replaces `createAssociatedTokenAccountInstruction` with `createAssociatedTokenAccountIdempotentInstruction`, which does not fail even if the ATA already exists.